### PR TITLE
Added support for unfinished API calls. Those calls are now rendered …

### DIFF
--- a/appstats.go
+++ b/appstats.go
@@ -92,9 +92,6 @@ func header(ctx context.Context) http.Header {
 func override(ctx context.Context, service, method string, in, out proto.Message) error {
 	stats := stats(ctx)
 
-	stats.wg.Add(1)
-	defer stats.wg.Done()
-
 	if service == "__go__" {
 		return appengine.APICall(ctx, service, method, in, out)
 	}
@@ -105,12 +102,20 @@ func override(ctx context.Context, service, method string, in, out proto.Message
 		Start:     time.Now(),
 		Offset:    time.Since(stats.Start),
 		StackData: string(debug.Stack()),
+		Pending:   true,
 	}
+
+	rpcIndex := len(stats.RPCStats)
+	stats.lock.Lock()
+	stats.RPCStats = append(stats.RPCStats, stat)
+	stats.lock.Unlock()
+
 	err := appengine.APICall(ctx, service, method, in, out)
 	stat.Duration = time.Since(stat.Start)
 	stat.In = in.String()
 	stat.Out = out.String()
 	stat.Cost = getCost(out)
+	stat.Pending = false
 
 	if len(stat.In) > ProtoMaxBytes {
 		stat.In = stat.In[:ProtoMaxBytes] + "..."
@@ -120,7 +125,7 @@ func override(ctx context.Context, service, method string, in, out proto.Message
 	}
 
 	stats.lock.Lock()
-	stats.RPCStats = append(stats.RPCStats, stat)
+	stats.RPCStats[rpcIndex] = stat
 	stats.Cost += stat.Cost
 	stats.lock.Unlock()
 	return err
@@ -174,8 +179,13 @@ const bufMaxLen = 1000000
 
 func save(ctx context.Context) {
 	stats := stats(ctx)
-	stats.wg.Wait()
 	stats.Duration = time.Since(stats.Start)
+
+	for i, stat := range stats.RPCStats {
+		if stat.Pending {
+			stats.RPCStats[i].ExtraDuration = time.Since(stat.Start)
+		}
+	}
 
 	var buf_part, buf_full bytes.Buffer
 	full := stats_full{

--- a/html.go
+++ b/html.go
@@ -463,9 +463,10 @@ function renderChart() {
   var chart = new Gantt();
   {{ range $index, $t := .Record.RPCStats }}
     chart.add_bar('{{$t.Name}}',
-        {{$t.Offset.Seconds}} * 1000, {{$t.Duration.Seconds}} * 1000,
-        0,
-        '{{$t.Duration}}',
+        {{$t.Offset.Seconds}} * 1000,
+        {{$t.Duration.Seconds}} * 1000,
+        {{$t.ExtraDuration.Seconds}} * 1000,
+        {{$t.Duration}},
         'javascript:timelineClickHandler(\'{{$index}}\');');
   {{ end }}
 

--- a/types.go
+++ b/types.go
@@ -46,7 +46,6 @@ type requestStats struct {
 	RPCStats    []rpcStat
 
 	lock sync.Mutex
-	wg   sync.WaitGroup
 }
 
 type stats_part requestStats
@@ -75,9 +74,11 @@ type rpcStat struct {
 	Start           time.Time
 	Offset          time.Duration
 	Duration        time.Duration
+	ExtraDuration   time.Duration
 	StackData       string
 	In, Out         string
 	Cost            int64
+	Pending         bool
 }
 
 func (r rpcStat) Name() string {


### PR DESCRIPTION
…with red bars using "extra" option in ghantt.js. This change is a must when implementing Control Variance.

Example sceenshot:
<img width="1263" alt="screen shot 2017-07-07 at 15 11 57" src="https://user-images.githubusercontent.com/7556088/27957352-cef1e4b0-6326-11e7-8437-4d65c134e74b.png">
